### PR TITLE
feat : Hospital reservation & approval Impl

### DIFF
--- a/src/main/java/com/weer/weer_backend/controller/HospitalInfoController.java
+++ b/src/main/java/com/weer/weer_backend/controller/HospitalInfoController.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -23,25 +24,27 @@ public class HospitalInfoController {
   private final HospitalInfoService hospitalInfoService;
 
   @GetMapping("/announcement")
-  public ResponseEntity<List<ERAnnouncementDTO>> getAnnouncement(@RequestParam("hospitalId") Long hospitalId) {
+  public ResponseEntity<List<ERAnnouncementDTO>> getAnnouncement(
+      @PathVariable(name = "hospitalid") Long hospitalId) {
     return ResponseEntity.ok(hospitalInfoService.getAnnounce(hospitalId));
   }
 
   @PostMapping("/info")
   public ResponseEntity<List<HospitalDTO>> filterHospital(@RequestParam Double lat
-      , @RequestParam Double lon, @RequestBody HospitalFilterDto filter){
-    return ResponseEntity.ok(hospitalInfoService.filteredHospitals(lat,lon,filter));
+      , @RequestParam Double lon, @RequestBody HospitalFilterDto filter) {
+    return ResponseEntity.ok(hospitalInfoService.filteredHospitals(lat, lon, filter));
   }
 
   @GetMapping("/location")
   public ResponseEntity<List<HospitalRangeDto>> getHospitalLocation(@RequestParam Double lat
-      , @RequestParam Double lon, @RequestParam Integer range){
+      , @RequestParam Double lon, @RequestParam Integer range) {
     return ResponseEntity.ok(hospitalInfoService.getRangeAllHospital(lat, lon, range));
   }
 
   @GetMapping("/detail")
-  public ResponseEntity<HospitalDTO> getHospitalDetail(@RequestParam Long id){
-    return ResponseEntity.ok(hospitalInfoService.getHospitalDetail(id));
+  public ResponseEntity<HospitalDTO> getHospitalDetail(
+      @PathVariable(name = "hospitalid") Long hospitalId) {
+    return ResponseEntity.ok(hospitalInfoService.getHospitalDetail(hospitalId));
   }
 
 

--- a/src/main/java/com/weer/weer_backend/controller/ReservationController.java
+++ b/src/main/java/com/weer/weer_backend/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package com.weer.weer_backend.controller;
 
 import com.weer.weer_backend.dto.ReservationDTO;
+import com.weer.weer_backend.dto.ReservationRequestDto;
 import com.weer.weer_backend.entity.Reservation;
 import com.weer.weer_backend.enums.ReservationStatus;
 import com.weer.weer_backend.service.ReservationService;
@@ -46,5 +47,10 @@ public class ReservationController {
     public ResponseEntity<Object> showHospitalReservation(@PathVariable(name = "hospitalid") Long hospitalid){
         List<Reservation> myReservation = reservationService.getHospitalReservation(hospitalid);
         return ResponseEntity.status(HttpStatus.OK).body(myReservation);
+    }
+
+    @PostMapping("/hospital/reserve")
+    public ResponseEntity<String> reserveHospital(@RequestBody ReservationRequestDto reservationDTO){
+        return ResponseEntity.ok(reservationService.reservationRequest(reservationDTO));
     }
 }

--- a/src/main/java/com/weer/weer_backend/dto/ReservationRequestDto.java
+++ b/src/main/java/com/weer/weer_backend/dto/ReservationRequestDto.java
@@ -1,0 +1,21 @@
+package com.weer.weer_backend.dto;
+
+import com.weer.weer_backend.entity.Reservation;
+import com.weer.weer_backend.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReservationRequestDto {
+  private Long patientconditionId;
+  private Long hospitalId;
+
+  public Reservation from(){
+    return Reservation.builder()
+        .hospitalId(this.hospitalId)
+        .patientconditionid(this.patientconditionId)
+        .reservationStatus(ReservationStatus.PENDING)
+        .build();
+  }
+}

--- a/src/main/java/com/weer/weer_backend/entity/Reservation.java
+++ b/src/main/java/com/weer/weer_backend/entity/Reservation.java
@@ -1,13 +1,16 @@
 package com.weer.weer_backend.entity;
 
 import com.weer.weer_backend.enums.ReservationStatus;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.Date;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -29,7 +32,8 @@ public class Reservation extends BaseEntity{
     @Enumerated(EnumType.STRING)
     private ReservationStatus reservationStatus;
 
-    public void changeStatus(ReservationStatus newStatus){
+    public Reservation changeStatus(ReservationStatus newStatus){
         this.reservationStatus = newStatus;
+        return this;
     }
 }

--- a/src/main/java/com/weer/weer_backend/service/ReservationService.java
+++ b/src/main/java/com/weer/weer_backend/service/ReservationService.java
@@ -1,29 +1,45 @@
 package com.weer.weer_backend.service;
 
 import com.weer.weer_backend.dto.ReservationDTO;
+import com.weer.weer_backend.dto.ReservationRequestDto;
 import com.weer.weer_backend.entity.Reservation;
 import com.weer.weer_backend.enums.ReservationStatus;
 import com.weer.weer_backend.repository.ReservationRepository;
+import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class ReservationService {
     private final ReservationRepository reservationRepository;
 
     // 병원에서 승인
+    @Transactional
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     public void reservationApprove(ReservationDTO reservationDTO) {
         Reservation reservation = reservationRepository.findByReservationId(reservationDTO.getReservationId());
-        reservation.changeStatus(ReservationStatus.APPROVED);
-        reservationRepository.save(reservation);
+        List<Reservation> reservationList = reservationRepository.findAllByPatientconditionid(
+            reservationDTO.getReservationId());
+        long count = reservationList.stream()
+            .filter(e -> e.getReservationStatus().equals(ReservationStatus.APPROVED))
+            .count();
+
+        if (count > 0) {
+            reservationList.stream()
+                .filter(r -> !r.getReservationStatus().equals(ReservationStatus.APPROVED))
+                .forEach(r -> reservationRepository.save(r.changeStatus(ReservationStatus.CANCELLED)));
+        } else if (!reservation.getReservationStatus().equals(ReservationStatus.APPROVED)) {
+            reservationRepository.save(reservation.changeStatus(ReservationStatus.APPROVED));
+        }
     }
 
+
     // 병원에서 거절
+    @Transactional
     public void reservationReject(ReservationDTO reservationDTO) {
         Reservation reservation = reservationRepository.findByReservationId(reservationDTO.getReservationId());
         reservation.changeStatus(ReservationStatus.DECLINED);
@@ -33,5 +49,14 @@ public class ReservationService {
     // 병원 별 예약 리스트
     public List<Reservation> getHospitalReservation(Long hospitalid){
         return reservationRepository.findAllByHospitalId(hospitalid);
+    }
+
+    public String reservationRequest(ReservationRequestDto reservationRequestDto){
+        try{
+            reservationRepository.save(reservationRequestDto.from());
+            return "success";
+        }catch (Exception e){
+            return "error";
+        }
     }
 }

--- a/src/test/java/com/weer/weer_backend/service/ReservationServiceIntegrationTest.java
+++ b/src/test/java/com/weer/weer_backend/service/ReservationServiceIntegrationTest.java
@@ -1,0 +1,74 @@
+package com.weer.weer_backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.weer.weer_backend.dto.ReservationDTO;
+import com.weer.weer_backend.entity.Reservation;
+import com.weer.weer_backend.enums.ReservationStatus;
+import com.weer.weer_backend.repository.ReservationRepository;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+class ReservationServiceIntegrationTest {
+
+  @Autowired
+  private ReservationService reservationService;
+
+  @Autowired
+  private ReservationRepository reservationRepository;
+
+  @Test
+  void testReservationApproveConcurrency() throws InterruptedException {
+    // Given
+    Reservation reservation = Reservation.builder()
+        .reservationId(1L)
+        .reservationStatus(ReservationStatus.PENDING)
+        .build();
+
+    reservationRepository.save(reservation);
+
+    ReservationDTO reservationDTO = ReservationDTO.builder()
+        .reservationId(1L)
+        .build();
+
+    int threadCount = 5;
+    ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch latch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+    for (int i = 0; i < threadCount; i++) {
+      executorService.execute(() -> {
+        try {
+          latch.await(); // 모든 스레드가 준비될 때까지 대기
+          reservationService.reservationApprove(reservationDTO);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          doneLatch.countDown(); // 작업 완료를 표시
+        }
+      });
+    }
+
+    latch.countDown(); // 모든 스레드가 동시에 시작하게 함
+    doneLatch.await(); // 모든 스레드가 완료될 때까지 대기
+    executorService.shutdown();
+
+    // Then: Verify that only one approval was made
+    List<Reservation> reservations = reservationRepository.findAll();
+    long approvedCount = reservations.stream()
+        .filter(r -> r.getReservationStatus() == ReservationStatus.APPROVED)
+        .count();
+
+    assertEquals(1, approvedCount);
+  }
+
+}
+

--- a/src/test/java/com/weer/weer_backend/service/ReservationServiceTest.java
+++ b/src/test/java/com/weer/weer_backend/service/ReservationServiceTest.java
@@ -1,0 +1,108 @@
+package com.weer.weer_backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.weer.weer_backend.dto.ReservationDTO;
+import com.weer.weer_backend.entity.Reservation;
+import com.weer.weer_backend.enums.ReservationStatus;
+import com.weer.weer_backend.repository.ReservationRepository;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ReservationServiceTest {
+
+  @Mock
+  private ReservationRepository reservationRepository;
+
+  @InjectMocks
+  private ReservationService reservationService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  void testReservationApproveWhenAlreadyApprovedExists() {
+    // Given
+    ReservationDTO reservationDTO = ReservationDTO.builder()
+        .reservationId(1L)
+        .build();
+
+    Reservation approvedReservation = Reservation.builder()
+        .reservationStatus(ReservationStatus.APPROVED)
+        .build();
+
+    Reservation pendingReservation = Reservation.builder()
+        .reservationStatus(ReservationStatus.PENDING)
+        .build();
+
+    List<Reservation> reservationList = Arrays.asList(approvedReservation, pendingReservation);
+
+    when(reservationRepository.findByReservationId(reservationDTO.getReservationId()))
+        .thenReturn(pendingReservation);
+    when(reservationRepository.findAllByPatientconditionid(reservationDTO.getReservationId()))
+        .thenReturn(reservationList);
+
+    // When
+    reservationService.reservationApprove(reservationDTO);
+
+    // Then
+    ArgumentCaptor<Reservation> reservationCaptor = ArgumentCaptor.forClass(Reservation.class);
+    verify(reservationRepository, times(1)).save(reservationCaptor.capture());
+
+    // Verify the captured Reservation object status is changed to CANCELLED
+    Reservation capturedReservation = reservationCaptor.getValue();
+    assertEquals(ReservationStatus.CANCELLED, capturedReservation.getReservationStatus());
+  }
+
+  @Test
+  void testReservationReject() {
+    // Given
+    ReservationDTO reservationDTO = ReservationDTO.builder()
+        .reservationId(1L)
+        .build();
+
+    Reservation reservation = Reservation.builder()
+        .reservationStatus(ReservationStatus.PENDING)
+        .build();
+
+    when(reservationRepository.findByReservationId(reservationDTO.getReservationId()))
+        .thenReturn(reservation);
+
+    // When
+    reservationService.reservationReject(reservationDTO);
+
+    // Then
+    assertEquals(ReservationStatus.DECLINED, reservation.getReservationStatus());
+    verify(reservationRepository).save(reservation);
+  }
+
+  @Test
+  void testGetHospitalReservation() {
+    // Given
+    Long hospitalId = 1L;
+    Reservation reservation1 = Reservation.builder().build();
+    Reservation reservation2 = Reservation.builder().build();
+    List<Reservation> reservationList = Arrays.asList(reservation1, reservation2);
+
+    when(reservationRepository.findAllByHospitalId(hospitalId)).thenReturn(reservationList);
+
+    // When
+    List<Reservation> result = reservationService.getHospitalReservation(hospitalId);
+
+    // Then
+    assertEquals(2, result.size());
+    verify(reservationRepository).findAllByHospitalId(hospitalId);
+  }
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #28

## 📝 작업 내용

이번 PR에서는 예약 승인 기능에서 발생하는 동시성 문제를 해결하기 위해 로직을 개선하였습니다.  
여러 스레드가 동시에 접근하여 중복 승인 상태가 발생하는 문제를 방지하기 위해 아래와 같은 수정 사항을 적용하였습니다.

1. **비관적 잠금(PESSIMISTIC_WRITE)과 트랜잭션 격리 수준(SERIALIZABLE) 적용**  
   - `@Transactional(isolation = Isolation.SERIALIZABLE)`과 `@Lock(LockModeType.PESSIMISTIC_WRITE)`를 통해 여러 트랜잭션이 동시에 같은 예약을 승인하지 못하도록 처리하였습니다.

2. **서비스 로직에서 추가 상태 검증**  
   - 예약의 상태가 이미 `APPROVED`인 경우, 중복 승인을 방지하기 위해 다시 저장하지 않도록 로직을 강화하였습니다.

3. **동시성 테스트 코드 작성**  
   - 다중 스레드 환경에서 승인 요청을 테스트하기 위해 `ExecutorService`와 `CountDownLatch`를 사용한 동시성 테스트 코드를 추가하여 실제 환경에서 동시성 제어가 제대로 동작하는지 확인하였습니다.