### PR TITLE
feat : Prometheus + Grafana Impl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM openjdk:21
+
+RUN mkdir -p deploy
+WORKDIR /deploy
+
+COPY build/libs/WeER_backend-0.0.1-SNAPSHOT.jar WeER_backend.jar
+
+ENTRYPOINT ["java","-jar","/deploy/WeER_backend.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'io.micrometer:micrometer-registry-prometheus'
-    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -47,6 +47,13 @@ dependencies {
 
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.14.1'
 
+}
+
+tasks.bootJar {
+    enabled = true
+}
+tasks.jar {
+    enabled = false // 기본 JAR 생성 비활성화
 }
 
 tasks.named('test') {

--- a/docker/docker-build.sh
+++ b/docker/docker-build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+#Setting Versions
+VERSION='1.0.0'
+
+export JAVA_HOME="C:/Users/2-20/.jdks/corretto-21.0.4"   # Java 17 경로로 변경하세요
+export PATH=$JAVA_HOME/bin:$PATH
+
+cd ..
+./gradlew clean build -x test
+
+ROOT_PATH=$(pwd)
+echo "$ROOT_PATH"
+
+echo 'api docker image build... Start'
+cd "$ROOT_PATH"/docker/ && docker build -t weer_backend:$VERSION .
+echo 'api docker image build... Finish'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  mysql:
+    image: mysql:latest
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: WeER
+    ports:
+      - "3306:3306"
+    networks:
+      - WeER
+
+  app:
+    image: weer_backend:1.0.0
+    ports:
+      - "8080:8080"
+    networks:
+      - WeER
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - WeER
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    networks:
+      - WeER
+
+networks:
+  WeER:
+    driver: bridge

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'spring-boot'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['app:8080']  # Spring Boot 애플리케이션의 이름과 포트

--- a/src/main/java/com/weer/weer_backend/config/SpringSecurityConfig.java
+++ b/src/main/java/com/weer/weer_backend/config/SpringSecurityConfig.java
@@ -13,7 +13,6 @@ public class SpringSecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf().disable() // CSRF 보호 비활성화 (개발용)
                 .authorizeRequests(authorize -> authorize
                         .requestMatchers("/api/emergency").permitAll() // /api/emergency 엔드포인트 접근 허용
                         .anyRequest().permitAll() // 그 외의 요청도 모두 접근 허용

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,27 +1,28 @@
 spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://mysql:3306/WeER?characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: root
+    password: root
+
   jpa:
-    generate-ddl: false
-    show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update  # 개발 시는 `update`를 권장 (운영에서는 `validate`나 `none`으로 변경)
+    show-sql: true
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQLDialect
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/WeER?characterEncoding=UTF-8&setTimezone=Asia/Seoul
-    username: root
-    password: root
   profiles:
     include: secret
-  management:
-    endpoints:
-      web:
-        exposure:
-          include: health,info,metrics,prometheus
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus  # Actuator에서 노출할 엔드포인트
+  prometheus:
     metrics:
       export:
-        prometheus:
-          enabled: true
+        enabled: true
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #32 

## 📝 작업 내용

이번 PR에서는 Prometheus와 Grafana를 이용하여 Spring Boot 애플리케이션의 주요 메트릭을 수집하고 시각화했습니다.

### Grafana와 Prometheus 시각화 작업

Prometheus를 통해 Spring Boot 애플리케이션의 `/actuator/prometheus` 엔드포인트에서 메트릭 데이터를 수집하고, Grafana에서 이를 시각화하여 대시보드를 생성했습니다.

1. **Prometheus 설정**:
   - `prometheus.yml` 파일을 사용하여 `app` 서비스의 `/actuator/prometheus` 엔드포인트를 스크랩하도록 설정하였습니다.
   - `scrape_interval`을 15초로 지정하여 메트릭 데이터를 주기적으로 수집하도록 구성했습니다.

2. **Grafana 대시보드**:
   - Grafana에서 Prometheus를 데이터 소스로 설정하여 Spring Boot 애플리케이션의 주요 메트릭을 시각화하는 대시보드를 만들었습니다.
   - **주요 대시보드 항목**:
     - **CPU 및 메모리 사용량**: Spring Boot 애플리케이션의 리소스 사용량을 모니터링하여 애플리케이션 성능을 파악할 수 있습니다.
     - **HTTP 요청 속도**: HTTP 요청의 처리 속도 및 성공/실패 비율을 모니터링합니다.
     - **데이터베이스 연결 상태**: MySQL 데이터베이스와의 연결 상태 및 쿼리 처리 속도를 모니터링합니다.
     - **GC(가비지 컬렉션) 활동**: 메모리 관리 효율성을 확인하기 위한 GC 활동을 모니터링합니다.

### 스크린샷 

> *Grafana 대시보드 스크린샷*
![image](https://github.com/user-attachments/assets/441a26b2-67e0-480e-b984-c63127993a4c)
![image](https://github.com/user-attachments/assets/37ee4ba1-09e1-473a-ade4-65bd2594ca35)

