### PR TITLE
#47 feat : ERAnnouncement Impl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.mysql:mysql-connector-j'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/weer/weer_backend/config/RedisConfig.java
+++ b/src/main/java/com/weer/weer_backend/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.weer.weer_backend.config;
+
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext.SerializationPair;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisConfig {
+
+  @Bean
+  public CacheManager cacheManager(RedisConnectionFactory cacheFactory) {
+    RedisCacheConfiguration redisCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+        .entryTtl(Duration.ofHours(1))  // TTL을 1시간으로 설정
+        .serializeKeysWith(SerializationPair.fromSerializer(
+            new StringRedisSerializer()))
+        .serializeValuesWith(SerializationPair.fromSerializer(
+            new GenericJackson2JsonRedisSerializer()));
+
+    return RedisCacheManager
+        .RedisCacheManagerBuilder
+        .fromConnectionFactory(cacheFactory)
+        .cacheDefaults(redisCacheConfig)
+        .build();
+  }
+}

--- a/src/main/java/com/weer/weer_backend/controller/HospitalInfoController.java
+++ b/src/main/java/com/weer/weer_backend/controller/HospitalInfoController.java
@@ -7,15 +7,16 @@ import com.weer.weer_backend.dto.HospitalRangeDto;
 import com.weer.weer_backend.service.HospitalInfoService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/hospital")
 @RequiredArgsConstructor
@@ -25,26 +26,50 @@ public class HospitalInfoController {
 
   @GetMapping("/announcement")
   public ResponseEntity<List<ERAnnouncementDTO>> getAnnouncement(
-      @PathVariable(name = "hospitalid") Long hospitalId) {
-    return ResponseEntity.ok(hospitalInfoService.getAnnounce(hospitalId));
+      @RequestParam(name = "hospitalid") Long hospitalId) {
+    long startTime = System.currentTimeMillis();
+    ResponseEntity<List<ERAnnouncementDTO>> response = ResponseEntity.ok(
+        hospitalInfoService.getAnnounce(hospitalId));
+    long endTime = System.currentTimeMillis();  // 종료 시간
+    long duration = endTime - startTime;  // 실행 시간 계산
+    log.info("Execution time of getAnnounce: {} ms", duration);
+    return response;
   }
 
   @PostMapping("/info")
   public ResponseEntity<List<HospitalDTO>> filterHospital(@RequestParam Double lat
       , @RequestParam Double lon, @RequestBody HospitalFilterDto filter) {
-    return ResponseEntity.ok(hospitalInfoService.filteredHospitals(lat, lon, filter));
+    long startTime = System.currentTimeMillis();
+    ResponseEntity<List<HospitalDTO>> response = ResponseEntity.ok(
+        hospitalInfoService.filteredHospitals(lat, lon, filter));
+    long endTime = System.currentTimeMillis();  // 종료 시간
+    long duration = endTime - startTime;  // 실행 시간 계산
+    log.info("Execution time of getFilterHospital : {} ms", duration);
+    return response;
   }
 
   @GetMapping("/location")
   public ResponseEntity<List<HospitalRangeDto>> getHospitalLocation(@RequestParam Double lat
       , @RequestParam Double lon, @RequestParam Integer range) {
-    return ResponseEntity.ok(hospitalInfoService.getRangeAllHospital(lat, lon, range));
+    long startTime = System.currentTimeMillis();
+    ResponseEntity<List<HospitalRangeDto>> response = ResponseEntity.ok(
+        hospitalInfoService.getRangeAllHospital(lat, lon, range));
+    long endTime = System.currentTimeMillis();  // 종료 시간
+    long duration = endTime - startTime;  // 실행 시간 계산
+    log.info("Execution time of getHospitalLocation : {} ms", duration);
+    return response;
   }
 
   @GetMapping("/detail")
   public ResponseEntity<HospitalDTO> getHospitalDetail(
-      @PathVariable(name = "hospitalid") Long hospitalId) {
-    return ResponseEntity.ok(hospitalInfoService.getHospitalDetail(hospitalId));
+      @RequestParam(name = "hospitalid") Long hospitalId) {
+    long startTime = System.currentTimeMillis();
+    ResponseEntity<HospitalDTO> response = ResponseEntity.ok(
+        hospitalInfoService.getHospitalDetail(hospitalId));
+    long endTime = System.currentTimeMillis();  // 종료 시간
+    long duration = endTime - startTime;  // 실행 시간 계산
+    log.info("Execution time of getHospitalDetail : {} ms", duration);
+    return response;
   }
 
 

--- a/src/main/java/com/weer/weer_backend/dto/ERAnnouncementDTO.java
+++ b/src/main/java/com/weer/weer_backend/dto/ERAnnouncementDTO.java
@@ -1,28 +1,30 @@
 package com.weer.weer_backend.dto;
 
 import com.weer.weer_backend.entity.ERAnnouncement;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-
-import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ERAnnouncementDTO {
     private Long announcementId;   // 공지사항 고유 ID
     private Long hospitalId;       // 병원 고유 ID
     private String msgType;        // 메시지 구분
     private String message;        // 공지 메시지 내용
     private String diseaseType;    // 중증 질환명
-    private LocalDateTime createdAt; // 등록 일시
+    private String createdAt; // 등록 일시
 
     public static ERAnnouncementDTO from(ERAnnouncement erAnnouncement){
         return ERAnnouncementDTO.builder()
             .announcementId(erAnnouncement.getAnnouncementId())
-            .hospitalId(erAnnouncement.getHospitalId())
+            .hospitalId(erAnnouncement.getHospitalId().getHospitalId())
             .msgType(erAnnouncement.getMsgType())
             .message(erAnnouncement.getMessage())
             .diseaseType(erAnnouncement.getDiseaseType())
-            .createdAt(erAnnouncement.getCreatedAt()).build();
+            .createdAt(erAnnouncement.getCreatedAt().toString()).build();
     }
 }

--- a/src/main/java/com/weer/weer_backend/entity/ERAnnouncement.java
+++ b/src/main/java/com/weer/weer_backend/entity/ERAnnouncement.java
@@ -1,12 +1,19 @@
 package com.weer.weer_backend.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -14,15 +21,16 @@ import java.time.LocalDateTime;
 @Builder
 @Entity
 @Table(name = "ER_ANNOUNCEMENT")
-public class ERAnnouncement {
+public class ERAnnouncement extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "ANNOUNCEMENT_ID")
     private Long announcementId;  // 공지사항 고유 ID
 
-    @Column(name = "HOSPITAL_ID")
-    private Long hospitalId;  // 병원 고유 ID
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
+    @JoinColumn(name = "HOSPITAL_ID")
+    private Hospital hospitalId;  // 병원 고유 ID
 
     @Column(name = "MSG_TYPE")
     private String msgType;  // 메시지 구분
@@ -32,7 +40,4 @@ public class ERAnnouncement {
 
     @Column(name = "DISEASE_TYPE")
     private String diseaseType;  // 중증 질환명
-
-    @Column(name = "CREATED_AT")
-    private LocalDateTime createdAt;  // 등록 일시
 }

--- a/src/main/java/com/weer/weer_backend/repository/ERAnnouncementRepository.java
+++ b/src/main/java/com/weer/weer_backend/repository/ERAnnouncementRepository.java
@@ -1,6 +1,7 @@
 package com.weer.weer_backend.repository;
 
 import com.weer.weer_backend.entity.ERAnnouncement;
+import com.weer.weer_backend.entity.Hospital;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ERAnnouncementRepository extends JpaRepository<ERAnnouncement, Long> {
     // 응급실 공지 관련 추가 메서드 정의 가능
-  List<ERAnnouncement> findAllByHospitalId(Long hospitalId);
+  List<ERAnnouncement> findAllByHospitalId(Hospital hospitalId);
 }

--- a/src/main/java/com/weer/weer_backend/repository/HospitalRepository.java
+++ b/src/main/java/com/weer/weer_backend/repository/HospitalRepository.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface HospitalRepository extends JpaRepository<Hospital, Long> {
     // 병원 관련 추가 메서드 정의 가능
-    List<Hospital> findByCityAndAndState(String city, String state);
+    List<Hospital> findByCityAndState(String city, String state);
     boolean existsByHpid(String hpid); // hpid로 중복 여부 확인
     Optional<Hospital> findByHpid(String hpid);
 

--- a/src/main/java/com/weer/weer_backend/service/ERAnnouncementService.java
+++ b/src/main/java/com/weer/weer_backend/service/ERAnnouncementService.java
@@ -1,0 +1,122 @@
+package com.weer.weer_backend.service;
+
+import com.weer.weer_backend.constants.DistrictConstants;
+import com.weer.weer_backend.entity.ERAnnouncement;
+import com.weer.weer_backend.entity.Hospital;
+import com.weer.weer_backend.event.DataUpdateCompleteEvent;
+import com.weer.weer_backend.repository.ERAnnouncementRepository;
+import com.weer.weer_backend.repository.HospitalRepository;
+import com.weer.weer_backend.util.XmlParsingUtils;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+@Service
+@RequiredArgsConstructor
+public class ERAnnouncementService {
+  private final ERAnnouncementRepository erAnnouncementRepository;
+  private final HospitalRepository hospitalRepository;
+  private final EntityManager entityManager; // Inject EntityManager
+
+  private final List<String> districts = DistrictConstants.DISTRICTS;
+
+  @Value("${OPENAPI_SERVICE_KEY}")
+  private String SERVICE_KEY;
+  private final String BASE_URL = "http://apis.data.go.kr/B552657/ErmctInfoInqireService/getEmrrmSrsillDissMsgInqire";
+  private final RestTemplate restTemplate;
+
+  @EventListener
+  public void handleDataUpdateCompleteEvent(DataUpdateCompleteEvent event) {
+    System.out.println("이벤트 수신: " + event.getMessage());
+    getHospitalInfoForAllDistricts();
+  }
+
+  @Transactional
+  public void getHospitalInfoForAllDistricts() {
+    int pageNo = 1;
+    int numOfRows = 10;
+    String stage1 = "서울특별시";
+    for (String stage2 : districts) {
+      getErAnnouncement(stage1, stage2, pageNo, numOfRows);
+    }
+  }
+
+  @Transactional
+  public String getErAnnouncement(String stage1, String stage2, int pageNo, int numOfRows) {
+    List<Hospital> hospitals = hospitalRepository.findByCityAndState(stage1, stage2);
+
+    for (Hospital hospital : hospitals) {
+
+      URI uri = UriComponentsBuilder.fromHttpUrl(BASE_URL)
+          .queryParam("serviceKey", SERVICE_KEY)
+          .queryParam("HPID", hospital.getHpid())
+          .queryParam("pageNo", pageNo)
+          .queryParam("numOfRows", numOfRows)
+          .encode(StandardCharsets.UTF_8)
+          .build()
+          .toUri();
+
+      System.out.println("요청 URI: " + uri);
+      String xmlResponse = restTemplate.getForObject(uri, String.class);
+      System.out.println("API 응답: " + xmlResponse);
+
+      try {
+        // XML 문자열을 Document 객체로 파싱
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        Document doc = builder.parse(new ByteArrayInputStream(xmlResponse.getBytes(StandardCharsets.UTF_8)));
+
+        // 응답 코드 확인
+        String resultCode = doc.getElementsByTagName("resultCode").item(0).getTextContent();
+        if (!"00".equals(resultCode)) {
+          String resultMsg = doc.getElementsByTagName("resultMsg").item(0).getTextContent();
+          return "API 호출 실패: " + resultMsg;
+        }
+
+        // item 노드 리스트 가져오기
+        NodeList items = doc.getElementsByTagName("item");
+        for (int i = 0; i < items.getLength(); i++) {
+          String rnum = XmlParsingUtils.getTextContentSafely(doc, "rnum", i);
+          String dutyAddr = XmlParsingUtils.getTextContentSafely(doc, "dutyAddr", i);
+          String dutyName = XmlParsingUtils.getTextContentSafely(doc, "dutyName", i);
+          String emcOrgCod = XmlParsingUtils.getTextContentSafely(doc, "emcOrgCod", i);
+          String hpid = XmlParsingUtils.getTextContentSafely(doc, "hpid", i);
+          String symBlkMsg = XmlParsingUtils.getTextContentSafely(doc, "symBlkMsg", i);
+          String symBlkMsgTyp = XmlParsingUtils.getTextContentSafely(doc, "symBlkMsgTyp", i);
+          String symTypCod = XmlParsingUtils.getTextContentSafely(doc, "symTypCod", i);
+          String symTypCodMag = XmlParsingUtils.getTextContentSafely(doc, "symTypCodMag", i);
+          String symOutDspYon = XmlParsingUtils.getTextContentSafely(doc, "symOutDspYon", i);
+          String symOutDspMth = XmlParsingUtils.getTextContentSafely(doc, "symOutDspMth", i);
+          String symBlkSttDtm = XmlParsingUtils.getTextContentSafely(doc, "symBlkSttDtm", i);
+          String symBlkDtm = XmlParsingUtils.getTextContentSafely(doc, "symBlkDtm", i);
+
+          ERAnnouncement erAnnouncement = ERAnnouncement.builder()
+              .hospitalId(hospital)  // Ensure hospital is managed
+              .msgType(symBlkMsgTyp)
+              .message(symBlkMsg)
+              .diseaseType(symTypCod).build();
+
+          erAnnouncementRepository.save(erAnnouncement);
+        }
+
+      } catch (Exception e) {
+        e.printStackTrace();
+        return "XML 파싱 오류 발생";
+      }
+    }
+    return "서울특별시 병원 공지 데이터가 저장되었습니다.";
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   jpa:
     generate-ddl: false
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: create
     properties:
@@ -25,3 +25,8 @@ spring:
       export:
         prometheus:
           enabled: true
+
+  data:
+    redis:
+      port: 6379
+      host: 127.0.0.1

--- a/src/test/java/com/weer/weer_backend/service/HospitalInfoServiceTest.java
+++ b/src/test/java/com/weer/weer_backend/service/HospitalInfoServiceTest.java
@@ -70,7 +70,7 @@ class HospitalInfoServiceTest {
         .icuId(icu)
         .build();
 
-    when(hospitalRepository.findByCityAndAndState("CityA", "StateA"))
+    when(hospitalRepository.findByCityAndState("CityA", "StateA"))
         .thenReturn(Collections.singletonList(hospital));
 
     // Act
@@ -79,7 +79,7 @@ class HospitalInfoServiceTest {
     // Assert
     assertNotNull(result);
     assertEquals(1, result.size());
-    verify(hospitalRepository, times(1)).findByCityAndAndState("CityA", "StateA");
+    verify(hospitalRepository, times(1)).findByCityAndState("CityA", "StateA");
   }
 
   @Test
@@ -199,7 +199,7 @@ class HospitalInfoServiceTest {
         .icuId(icu)
         .build();
 
-    when(hospitalRepository.findByCityAndAndState("CityA", "StateA"))
+    when(hospitalRepository.findByCityAndState("CityA", "StateA"))
         .thenReturn(Collections.singletonList(hospital));
 
     // Act
@@ -209,6 +209,6 @@ class HospitalInfoServiceTest {
     assertNotNull(result);
     assertEquals(1, result.size());
     assertTrue(result.stream().allMatch(h -> h.getCity().equals("CityA")));
-    verify(hospitalRepository, times(1)).findByCityAndAndState("CityA", "StateA");
+    verify(hospitalRepository, times(1)).findByCityAndState("CityA", "StateA");
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #47

## 📝작업 내용

> 이번 PR에서는 `@ManyToOne` 관계에서 발생한 `detached entity passed to persist` 예외를 해결하기 위해, `cascade = CascadeType.MERGE`를 추가하여 병원 엔티티가 병합될 때 함께 처리되도록 했습니다. 이 예외는 `Hospital` 엔티티가 "detached" 상태로 존재할 때 발생했으며, 해당 상태에서 `persist()` 호출 시 Hibernate가 객체를 관리하지 못하게 되면서 발생한 문제였습니다. 
>
> **문제 해결 과정**:
> - 먼저, 병원 엔티티가 detached 상태일 때 발생하는 `PersistentObjectException`을 분석했습니다. 이 문제는 객체가 세션과 분리된 후에 `persist()` 메서드를 호출하여 발생합니다.
> - `cascade = CascadeType.MERGE`를 추가하여 병원 엔티티가 `persist()` 대신 `merge()`로 병합되도록 하여, detached 상태의 엔티티가 세션에 다시 연결되도록 했습니다.
> - 이로 인해 연관된 `Hospital` 엔티티가 데이터베이스에 올바르게 반영되도록 수정되었습니다.

```java
@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)
@JoinColumn(name = "HOSPITAL_ID")
private Hospital hospitalId;  // 병원 고유 ID
```

### 트러블슈팅 상세

#### 문제 분석:
- `detached entity passed to persist` 오류는 `Hospital` 엔티티가 현재 `Session`에 의해 관리되지 않아서 발생했습니다.
- `persist()`는 새로운 객체를 세션에 저장하는 데 사용되며, 기존에 데이터베이스에 저장된 객체를 세션에 병합하려면 `merge()`를 사용해야 합니다.
- 이 문제는 객체가 세션과 분리된 후(`detached` 상태) `persist()` 메서드를 호출하면서 발생한 것입니다.

#### 문제 원인:
- `@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.MERGE)` 설정에서 `Hospital` 객체가 detached 상태로 존재할 때, `save()` 또는 `persist()`를 호출했을 경우, Hibernate는 `Hospital` 엔티티가 이미 데이터베이스에 존재한다고 인식하지 않고 새로 저장하려고 시도하여 `PersistentObjectException`을 발생시킵니다.

#### 해결 과정:
- `CascadeType.MERGE`를 사용하여, `Hospital` 엔티티가 이미 존재할 경우 해당 엔티티를 병합하도록 했습니다. 이는 `merge()` 메서드처럼 작동하게 되어, `Hospital`이 detached 상태여도 Hibernate가 세션에 다시 연결하고, 상태를 갱신하게 됩니다.
- 병원 엔티티가 `cascade = CascadeType.MERGE` 옵션에 의해 자동으로 병합되도록 하여, 관련 엔티티들이 올바르게 처리될 수 있도록 했습니다.

#### 테스트 및 검증:
- 병원 엔티티가 detached 상태에서 관련 엔티티에 병합될 때 예외가 발생하지 않도록 수정했습니다.
- 추가적으로 `Hospital` 엔티티를 먼저 `merge()` 메서드를 통해 병합하거나, 병원 정보가 변경될 경우 `@Transactional` 어노테이션을 사용하여 트랜잭션 내에서 연관된 엔티티들이 모두 관리될 수 있도록 했습니다.
- 모든 관련 엔티티들이 올바르게 병합되었는지 확인하고, 예외가 해결되었음을 검증했습니다.

