### PR TITLE
feat: 환자 이송 상태 변경 로직 추가

### DIFF
--- a/src/main/java/com/weer/weer_backend/config/SpringSecurityConfig.java
+++ b/src/main/java/com/weer/weer_backend/config/SpringSecurityConfig.java
@@ -40,7 +40,7 @@ public class SpringSecurityConfig {
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
         .authorizeHttpRequests(authorize -> authorize
-            .requestMatchers("/api/**", "/auth/**", "swagger-ui/**", "/v3/api-docs/**").permitAll()
+            .requestMatchers("/api/**", "/auth/**", "swagger-ui/**", "/v3/api-docs/**", "**").permitAll()
             .anyRequest().authenticated())
         .exceptionHandling(handling -> handling
             .authenticationEntryPoint((request, response, authException) -> {

--- a/src/main/java/com/weer/weer_backend/controller/PatientController.java
+++ b/src/main/java/com/weer/weer_backend/controller/PatientController.java
@@ -15,6 +15,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,6 +43,30 @@ public class PatientController {
                     .body(ApiResponse.success(responseDTO, "환자 상태가 성공적으로 등록되었습니다."));
         } catch (IllegalArgumentException e) {
             throw new CustomException(ErrorCode.PATIENT_SAVE_FAIL);
+        }
+    }
+
+    // 환자의 transportStatus를 COMPLETED로 업데이트하는 엔드포인트
+    @PatchMapping("/hospital/patient/{patient_id}/complete")
+    public ResponseEntity<ApiResponse<PatientConditionResponseDTO>> completePatientTransportStatus(
+            @PathVariable(name = "patient_id") Long patientId) {
+        try {
+            PatientCondition updatedCondition = patientService.updatePatientTransportStatusToCompleted(patientId);
+            PatientConditionResponseDTO responseDTO = PatientConditionResponseDTO.fromEntity(updatedCondition);
+
+            return ResponseEntity.ok(ApiResponse.success(responseDTO, "환자 이송 상태가 COMPLETED로 업데이트되었습니다."));
+        } catch (CustomException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(ApiResponse.<PatientConditionResponseDTO>builder()
+                            .status(HttpStatus.NOT_FOUND.value())
+                            .message("해당 환자를 찾을 수 없습니다.")
+                            .build());
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.<PatientConditionResponseDTO>builder()
+                            .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+                            .message("환자 이송 상태 업데이트 중 오류가 발생했습니다.")
+                            .build());
         }
     }
 

--- a/src/main/java/com/weer/weer_backend/entity/PatientCondition.java
+++ b/src/main/java/com/weer/weer_backend/entity/PatientCondition.java
@@ -6,13 +6,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
-@Builder
+@Builder(toBuilder = true)
 @Entity
 @Table(name = "PATIENT_CONDITION")
+@DynamicUpdate
 public class PatientCondition extends BaseEntity {
 
     @Id

--- a/src/main/java/com/weer/weer_backend/exception/ErrorCode.java
+++ b/src/main/java/com/weer/weer_backend/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
 
   //Patient
   PATIENT_SAVE_FAIL(HttpStatus.BAD_REQUEST,"환자 상태 저장에 실패했습니다."),
+  PATIENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "환자 정보가 존재하지 않습니다."),
 
   //locationInfo
   NOT_FOUND_ROUTE(HttpStatus.BAD_REQUEST,"경로를 찾을 수 없습니다.");


### PR DESCRIPTION
## #️⃣연관된 이슈

> #67 

## 📝작업 내용

> 환자의 transportStatus를 **COMPLETED**로 업데이트하는 API를 구현했습니다. 주요 변경 사항인 toBuilder와 PATCH 메서드 사용 이유를 포함하여 아래와 같습니다.

### build가 아닌 toBuilder를 사용한 이유, @DynamicUpdate 사용 이유
toBuilder를 사용하면 기존 엔티티의 모든 필드를 복사하여 일부 필드만 변경할 수 있습니다. 이는 코드의 가독성을 높이고 필드 일부만 변경할 때 새로운 객체를 생성하는 build 방식보다 효율적입니다.

또한 @DynamicUpdate 어노테이션을 통해 변경된 필드만 포함하여 SQL 업데이트 쿼리가 생성되도록 설정하여 불필요한 전체 필드 업데이트를 방지하고, 데이터베이스 성능을 최적화하고자 하였습니다.
```java
// 기존 객체의 필드를 유지하고, transportStatus만 COMPLETED로 변경
@DynamicUpdate
@Entity
PatientCondition updatedCondition = patientCondition.toBuilder()
        .transportStatus(TransportStatus.COMPLETED)
        .build();
```

### POST가 아닌 PATCH를 사용한 이유
PATCH는 리소스의 일부 필드만 수정할 때 사용되는 HTTP 메서드로, transportStatus 필드만 업데이트하는 해당 API의 목적에 맞습니다. POST는 주로 리소스 생성에 사용되므로, 이 상황에서는 PATCH가 RESTful 원칙에 더 적합하다고 판단하였습니다.
```java
@PatchMapping("/hospital/patient/{patient_id}/complete")
public ResponseEntity<ApiResponse<PatientConditionResponseDTO>> completePatientTransportStatus(@PathVariable Long patientId) {
    ...
}
```

### 스크린샷
<img width="1045" alt="스크린샷 2024-11-14 오전 11 44 27" src="https://github.com/user-attachments/assets/61253bc4-dd61-4a38-8f15-d5beb9e72691">


