### PR TITLE
feat : 병원측 예약요청 환자 정보 제시 구현

### DIFF
--- a/src/main/java/com/weer/weer_backend/controller/ReservationController.java
+++ b/src/main/java/com/weer/weer_backend/controller/ReservationController.java
@@ -1,8 +1,10 @@
 package com.weer.weer_backend.controller;
 
 import com.weer.weer_backend.dto.ApiResponse;
+import com.weer.weer_backend.dto.PatientConditionResponseDTO;
 import com.weer.weer_backend.dto.ReservationDTO;
 import com.weer.weer_backend.dto.ReservationRequestDto;
+import com.weer.weer_backend.entity.PatientCondition;
 import com.weer.weer_backend.entity.Reservation;
 import com.weer.weer_backend.enums.ReservationStatus;
 import com.weer.weer_backend.service.ReservationService;
@@ -45,7 +47,15 @@ public class ReservationController {
     @GetMapping("/hospitals/reservations/{hospitalid}")
     public ApiResponse<List<Reservation>> showHospitalReservation(@PathVariable(name = "hospitalid") Long hospitalid){
         List<Reservation> myReservation = reservationService.getHospitalReservation(hospitalid);
+
         return ApiResponse.success(myReservation);
+    }
+
+    // 병원에 예약 요청을 보낸 환자들의 건강 정보 리스트
+    @GetMapping("/hospitals/patients-info/{patients}")
+    public ApiResponse<List<PatientConditionResponseDTO>> showRequestedPatientsInfo(@PathVariable(name = "patients") List<Long> patientsConditionId){
+
+        return ApiResponse.success(reservationService.getPatientConditionList(patientsConditionId));
     }
 
     @PostMapping("/hospital/reserve")

--- a/src/main/java/com/weer/weer_backend/repository/PatientConditionRepository.java
+++ b/src/main/java/com/weer/weer_backend/repository/PatientConditionRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 @Repository
 public interface PatientConditionRepository extends JpaRepository<PatientCondition, Long>{
     List<PatientCondition> findAllByUserId(Long userId);
+
+    List<PatientCondition> findAllByPatientconditionidIn(List<Long> patientconditionIds);
 }

--- a/src/main/java/com/weer/weer_backend/service/ReservationService.java
+++ b/src/main/java/com/weer/weer_backend/service/ReservationService.java
@@ -1,13 +1,18 @@
 package com.weer.weer_backend.service;
 
+import com.weer.weer_backend.dto.PatientConditionResponseDTO;
 import com.weer.weer_backend.dto.ReservationDTO;
 import com.weer.weer_backend.dto.ReservationRequestDto;
+import com.weer.weer_backend.entity.PatientCondition;
 import com.weer.weer_backend.entity.Reservation;
 import com.weer.weer_backend.enums.ReservationStatus;
+import com.weer.weer_backend.repository.PatientConditionRepository;
 import com.weer.weer_backend.repository.ReservationRepository;
 import jakarta.persistence.LockModeType;
 import jakarta.transaction.Transactional;
 import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.stereotype.Service;
@@ -16,7 +21,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ReservationService {
     private final ReservationRepository reservationRepository;
-
+    private final PatientConditionRepository patientConditionRepository;
     // 병원에서 승인
     @Transactional
     @Lock(LockModeType.PESSIMISTIC_WRITE)
@@ -58,5 +63,13 @@ public class ReservationService {
         }catch (Exception e){
             return e.getMessage();
         }
+    }
+
+    // 환자들의 건강 정보 리스트
+    public List<PatientConditionResponseDTO> getPatientConditionList(List<Long> patientsConditionId) {
+        List<PatientCondition> patientConditions = patientConditionRepository.findAllByPatientconditionidIn(patientsConditionId);
+        return patientConditions.stream()
+                .map(PatientConditionResponseDTO::fromEntity)
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #75 

## 📝작업 내용

> 웹에서 병원 관리자가 병원으로 예약을 요청된 환자들의 정보를 볼 수 있어야 한다.
예약요청이 들어온 환자, 응급구조사의 id를 확인할 수 있으나 환자의 Condition을 가져오는 기능은 없었으므로 이를 구현.

 메서드 추가
- ReservationController : `showRequestedPatientsInfo`
- ReservationService : `getPatientConditionList`
- patientConditionRepository : `findAllByPatientconditionidIn`

