### PR TITLE
fix : hospitalFilter NPE

### DIFF
--- a/src/main/java/com/weer/weer_backend/service/HospitalInfoService.java
+++ b/src/main/java/com/weer/weer_backend/service/HospitalInfoService.java
@@ -62,42 +62,71 @@ public class HospitalInfoService {
     return h.getIcuId() != null || h.getEmergencyId() != null || h.getEquipmentId() != null;
   }
 
-  private boolean applyEmergencyFilters(Hospital h, HospitalFilterDto filter) {
-    return (!filter.isHvec() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHvec() > 0).orElse(false))
-        && (!filter.isHv27() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv27() > 0).orElse(false))
-        && (!filter.isHv29() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv29() > 0).orElse(false))
-        && (!filter.isHv30() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv30() > 0).orElse(false))
-        && (!filter.isHv28() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv28() > 0).orElse(false))
-        && (!filter.isHv15() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv15() > 0).orElse(false))
-        && (!filter.isHv16() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv16() > 0).orElse(false));
+  private boolean applyEmergencyFilters(Hospital hospital, HospitalFilterDto filter) {
+    return (!filter.isHvec() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHvec() != null && emergency.getHvec() > 0).orElse(false))
+        && (!filter.isHv27() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHv27() != null && emergency.getHv27() > 0).orElse(false))
+        && (!filter.isHv29() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHv29() != null && emergency.getHv29() > 0).orElse(false))
+        && (!filter.isHv30() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHv30() != null && emergency.getHv30() > 0).orElse(false))
+        && (!filter.isHv28() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHv28() != null && emergency.getHv28() > 0).orElse(false))
+        && (!filter.isHv15() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHv15() != null && emergency.getHv15() > 0).orElse(false))
+        && (!filter.isHv16() || Optional.ofNullable(hospital.getEmergencyId())
+        .map(emergency -> emergency.getHv16() != null && emergency.getHv16() > 0).orElse(false));
   }
 
-  private boolean applyICUFilters(Hospital h, HospitalFilterDto filter) {
-    return (!filter.isHvcc() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHvcc() > 0).orElse(false))
-        && (!filter.isHvncc() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHvncc() > 0).orElse(false))
-        && (!filter.isHvccc() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHvccc() > 0).orElse(false))
-        && (!filter.isHvicc() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHvicc() > 0).orElse(false))
-        && (!filter.isHv2() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv2() > 0).orElse(false))
-        && (!filter.isHv3() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv3() > 0).orElse(false))
-        && (!filter.isHv6() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv6() > 0).orElse(false))
-        && (!filter.isHv8() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv8() > 0).orElse(false))
-        && (!filter.isHv9() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv9() > 0).orElse(false))
-        && (!filter.isHv32() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv32() > 0).orElse(false))
-        && (!filter.isHv34() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv34() > 0).orElse(false))
-        && (!filter.isHv35() || Optional.ofNullable(h.getIcuId()).map(icu -> icu.getHv35() > 0).orElse(false));
+  private boolean applyICUFilters(Hospital hospital, HospitalFilterDto filter) {
+    return (!filter.isHvcc() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHvcc() != null && icu.getHvcc() > 0).orElse(false))
+        && (!filter.isHvncc() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHvncc() != null && icu.getHvncc() > 0).orElse(false))
+        && (!filter.isHvccc() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHvccc() != null && icu.getHvccc() > 0).orElse(false))
+        && (!filter.isHvicc() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHvicc() != null && icu.getHvicc() > 0).orElse(false))
+        && (!filter.isHv2() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv2() != null && icu.getHv2() > 0).orElse(false))
+        && (!filter.isHv3() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv3() != null && icu.getHv3() > 0).orElse(false))
+        && (!filter.isHv6() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv6() != null && icu.getHv6() > 0).orElse(false))
+        && (!filter.isHv8() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv8() != null && icu.getHv8() > 0).orElse(false))
+        && (!filter.isHv9() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv9() != null && icu.getHv9() > 0).orElse(false))
+        && (!filter.isHv32() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv32() != null && icu.getHv32() > 0).orElse(false))
+        && (!filter.isHv34() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv34() != null && icu.getHv34() > 0).orElse(false))
+        && (!filter.isHv35() || Optional.ofNullable(hospital.getIcuId())
+        .map(icu -> icu.getHv35() != null && icu.getHv35() > 0).orElse(false));
   }
 
-  private boolean applyEquipmentFilters(Hospital h, HospitalFilterDto filter) {
-    return (!filter.isHvventiAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvventiAYN()).orElse(false))
-        && (!filter.isHvventisoAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvventisoAYN()).orElse(false))
-        && (!filter.isHvinCUAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvinCUAYN()).orElse(false))
-        && (!filter.isHvcrrTAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvcrrTAYN()).orElse(false))
-        && (!filter.isHvecmoAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvecmoAYN()).orElse(false))
-        && (!filter.isHvhypoAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvhypoAYN()).orElse(false))
-        && (!filter.isHvoxyAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvoxyAYN()).orElse(false))
-        && (!filter.isHvctAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvctAYN()).orElse(false))
-        && (!filter.isHvmriAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvmriAYN()).orElse(false))
-        && (!filter.isHvangioAYN() || Optional.ofNullable(h.getEquipmentId()).map(equip -> equip.getHvangioAYN()).orElse(false));
+  private boolean applyEquipmentFilters(Hospital hospital, HospitalFilterDto filter) {
+    return (!filter.isHvventiAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvventiAYN())).orElse(false))
+        && (!filter.isHvventisoAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvventisoAYN())).orElse(false))
+        && (!filter.isHvinCUAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvinCUAYN())).orElse(false))
+        && (!filter.isHvcrrTAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvcrrTAYN())).orElse(false))
+        && (!filter.isHvecmoAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvecmoAYN())).orElse(false))
+        && (!filter.isHvhypoAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvhypoAYN())).orElse(false))
+        && (!filter.isHvoxyAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvoxyAYN())).orElse(false))
+        && (!filter.isHvctAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvctAYN())).orElse(false))
+        && (!filter.isHvmriAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvmriAYN())).orElse(false))
+        && (!filter.isHvangioAYN() || Optional.ofNullable(hospital.getEquipmentId())
+        .map(equipment -> Boolean.TRUE.equals(equipment.getHvangioAYN())).orElse(false));
   }
 
 
@@ -107,7 +136,8 @@ public class HospitalInfoService {
     return HospitalDTO.from(hospital);
   }
 
-  public List<HospitalDistanceDto> getDistanceAllHospital(Double latitude, Double longitude, int range) {
+  public List<HospitalDistanceDto> getDistanceAllHospital(Double latitude, Double longitude,
+      int range) {
     final int METERS_IN_KILOMETER = 1000;
     int rangeMeters = range * METERS_IN_KILOMETER;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #79 

## 📝 작업 내용

> 이번 PR에서 `NullPointerException` 이슈를 해결하기 위해 병원 필터링 로직을 수정했습니다.  
> 구체적으로는 병원 데이터가 `null`일 경우 발생하는 예외를 처리하고, 보다 안정적인 필터링이 가능하도록 개선했습니다.

### 트러블슈팅 상세 내용

### 1. 문제 상황
서비스에서 병원을 필터링할 때 `NullPointerException`이 발생했습니다.  
이는 `applyEmergencyFilters`, `applyICUFilters`, `applyEquipmentFilters` 메서드에서 필터링을 수행할 때, 특정 필드가 `null`인 경우 발생했습니다.

- **구체적인 에러 메시지:**
  ```java
  java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "com.weer.weer_backend.entity.Emergency.getHv27()" is null```

- **발생한 위치:**
  
  ```java
  private boolean applyEmergencyFilters(Hospital h, HospitalFilterDto filter) {
      return (!filter.isHvec() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHvec() > 0).orElse(false))
          && (!filter.isHv27() || Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv27() > 0).orElse(false));
          // ...
  }```

### 2. 원인 분석

이 예외는 `Optional.ofNullable(h.getEmergencyId()).map(e -> e.getHv27() > 0)`에서 `getHv27()`의 반환 값이 `null`인 경우 발생했습니다.  
`map` 함수는 내부에서 전달된 람다 표현식이 `null`이 아닌 값을 반환할 것을 기대하지만, `e.getHv27()`이 `null`이면 `NullPointerException`이 발생하게 됩니다.

- `Emergency` 객체의 특정 필드가 `null`인 경우를 대비해 `null` 처리가 필요했습니다.

### 3. 해결 방법

각 필터 조건에서 `Optional`과 `!= null` 체크를 사용하여 `null` 값을 안전하게 처리하도록 코드를 개선했습니다.  
또한, Boolean 타입 필드는 `Boolean.TRUE.equals()`를 사용하여 안정성을 높였습니다.

#### 변경된 코드:

```java
private boolean applyEmergencyFilters(Hospital hospital, HospitalFilterDto filter) {
    return (!filter.isHvec() || Optional.ofNullable(hospital.getEmergencyId())
        .map(emergency -> emergency.getHvec() != null && emergency.getHvec() > 0).orElse(false))
        && (!filter.isHv27() || Optional.ofNullable(hospital.getEmergencyId())
        .map(emergency -> emergency.getHv27() != null && emergency.getHv27() > 0).orElse(false));
        // ...
}

private boolean applyEquipmentFilters(Hospital hospital, HospitalFilterDto filter) {
    return (!filter.isHvventiAYN() || Optional.ofNullable(hospital.getEquipmentId())
        .map(equipment -> Boolean.TRUE.equals(equipment.getHvventiAYN())).orElse(false))
        // ...
}

```

- `null` 체크 후 값이 있을 때만 비교하여 `Optional`로 기본값을 `false`로 설정했습니다.
- Boolean 값의 경우 `Boolean.TRUE.equals()`를 사용하여 `null` 안정성을 확보했습니다.

### 4. 추가 확인 및 테스트

- 다양한 `null` 값을 포함하는 병원 데이터를 사용해 예외가 발생하지 않는지 테스트했습니다.
- 각 필터 조건이 의도대로 동작하는지 확인했습니다.



